### PR TITLE
Update repo URLs and add platform detection for GitHub/GitBucket

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Jesse Vincent",
     "email": "jesse@fsck.com"
   },
-  "homepage": "https://github.com/obra/superpowers",
-  "repository": "https://github.com/obra/superpowers",
+  "homepage": "https://github.com/NewsRx/opencode-gitbucket-superpowers",
+  "repository": "https://github.com/NewsRx/opencode-gitbucket-superpowers",
   "license": "MIT",
   "keywords": [
     "skills",

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -10,7 +10,7 @@ Enable superpowers skills in Codex via native skill discovery. Just clone and sy
 
 1. **Clone the superpowers repository:**
    ```bash
-   git clone https://github.com/obra/superpowers.git ~/.codex/superpowers
+   git clone https://github.com/NewsRx/opencode-gitbucket-superpowers.git ~/.codex/superpowers
    ```
 
 2. **Create the skills symlink:**

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -7,8 +7,8 @@
     "name": "Jesse Vincent",
     "email": "jesse@fsck.com"
   },
-  "homepage": "https://github.com/obra/superpowers",
-  "repository": "https://github.com/obra/superpowers",
+  "homepage": "https://github.com/NewsRx/opencode-gitbucket-superpowers",
+  "repository": "https://github.com/NewsRx/opencode-gitbucket-superpowers",
   "license": "MIT",
   "keywords": [
     "skills",

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 node_modules/
 inspo
 triage/
+.idea/

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -10,7 +10,7 @@ Add superpowers to the `plugin` array in your `opencode.json` (global or project
 
 ```json
 {
-  "plugin": ["superpowers@git+https://github.com/obra/superpowers.git"]
+  "plugin": ["superpowers@git+https://github.com/NewsRx/opencode-gitbucket-superpowers.git"]
 }
 ```
 
@@ -52,7 +52,7 @@ To pin a specific version:
 
 ```json
 {
-  "plugin": ["superpowers@git+https://github.com/obra/superpowers.git#v5.0.3"]
+  "plugin": ["superpowers@git+https://github.com/NewsRx/opencode-gitbucket-superpowers.git#v5.0.3"]
 }
 ```
 
@@ -79,5 +79,5 @@ When skills reference Claude Code tools:
 
 ## Getting Help
 
-- Report issues: https://github.com/obra/superpowers/issues
-- Full documentation: https://github.com/obra/superpowers/blob/main/docs/README.opencode.md
+- Report issues: https://github.com/NewsRx/opencode-gitbucket-superpowers/issues
+- Full documentation: https://github.com/NewsRx/opencode-gitbucket-superpowers/blob/main/docs/README.opencode.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Fixed
 
-- **Brainstorm server ESM fix**: Renamed `server.js` → `server.cjs` so the brainstorming server starts correctly on Node.js 22+ where the root `package.json` `"type": "module"` caused `require()` to fail. ([PR #784](https://github.com/obra/superpowers/pull/784) by @sarbojitrana, fixes [#774](https://github.com/obra/superpowers/issues/774), [#780](https://github.com/obra/superpowers/issues/780), [#783](https://github.com/obra/superpowers/issues/783))
-- **Brainstorm owner-PID on Windows**: Skip `BRAINSTORM_OWNER_PID` lifecycle monitoring on Windows/MSYS2 where the PID namespace is invisible to Node.js. Prevents the server from self-terminating after 60 seconds. The 30-minute idle timeout remains as the safety net. ([#770](https://github.com/obra/superpowers/issues/770), docs from [PR #768](https://github.com/obra/superpowers/pull/768) by @lucasyhzhu-debug)
-- **stop-server.sh reliability**: Verify the server process actually died before reporting success. Waits up to 2 seconds for graceful shutdown, escalates to `SIGKILL`, and reports failure if the process survives. ([#723](https://github.com/obra/superpowers/issues/723))
+- **Brainstorm server ESM fix**: Renamed `server.js` → `server.cjs` so the brainstorming server starts correctly on Node.js 22+ where the root `package.json` `"type": "module"` caused `require()` to fail. ([PR #784](https://github.com/NewsRx/opencode-gitbucket-superpowers/pull/784) by @sarbojitrana, fixes [#774](https://github.com/NewsRx/opencode-gitbucket-superpowers/issues/774), [#780](https://github.com/NewsRx/opencode-gitbucket-superpowers/issues/780), [#783](https://github.com/NewsRx/opencode-gitbucket-superpowers/issues/783))
+- **Brainstorm owner-PID on Windows**: Skip `BRAINSTORM_OWNER_PID` lifecycle monitoring on Windows/MSYS2 where the PID namespace is invisible to Node.js. Prevents the server from self-terminating after 60 seconds. The 30-minute idle timeout remains as the safety net. ([#770](https://github.com/NewsRx/opencode-gitbucket-superpowers/issues/770), docs from [PR #768](https://github.com/NewsRx/opencode-gitbucket-superpowers/pull/768) by @lucasyhzhu-debug)
+- **stop-server.sh reliability**: Verify the server process actually died before reporting success. Waits up to 2 seconds for graceful shutdown, escalates to `SIGKILL`, and reports failure if the process survives. ([#723](https://github.com/NewsRx/opencode-gitbucket-superpowers/issues/723))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Install the plugin from Claude marketplace:
 In Claude Code, register the marketplace first:
 
 ```bash
-/plugin marketplace add obra/superpowers-marketplace
+/plugin marketplace add NewsRx/superpowers-marketplace
 ```
 
 Then install the plugin from this marketplace:
@@ -67,7 +67,7 @@ or search for "superpowers" in the plugin marketplace.
 Tell Codex:
 
 ```
-Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.codex/INSTALL.md
+Fetch and follow instructions from https://raw.githubusercontent.com/NewsRx/opencode-gitbucket-superpowers/refs/heads/main/.codex/INSTALL.md
 ```
 
 **Detailed docs:** [docs/README.codex.md](docs/README.codex.md)
@@ -77,7 +77,7 @@ Fetch and follow instructions from https://raw.githubusercontent.com/obra/superp
 Tell OpenCode:
 
 ```
-Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.opencode/INSTALL.md
+Fetch and follow instructions from https://raw.githubusercontent.com/NewsRx/opencode-gitbucket-superpowers/refs/heads/main/.opencode/INSTALL.md
 ```
 
 **Detailed docs:** [docs/README.opencode.md](docs/README.opencode.md)
@@ -85,14 +85,14 @@ Fetch and follow instructions from https://raw.githubusercontent.com/obra/superp
 ### GitHub Copilot CLI
 
 ```bash
-copilot plugin marketplace add obra/superpowers-marketplace
+copilot plugin marketplace add NewsRx/superpowers-marketplace
 copilot plugin install superpowers@superpowers-marketplace
 ```
 
 ### Gemini CLI
 
 ```bash
-gemini extensions install https://github.com/obra/superpowers
+gemini extensions install https://github.com/NewsRx/opencode-gitbucket-superpowers
 ```
 
 To update:
@@ -186,5 +186,5 @@ MIT License - see LICENSE file for details
 Superpowers is built by [Jesse Vincent](https://blog.fsck.com) and the rest of the folks at [Prime Radiant](https://primeradiant.com).
 
 - **Discord**: [Join us](https://discord.gg/35wsABTejz) for community support, questions, and sharing what you're building with Superpowers
-- **Issues**: https://github.com/obra/superpowers/issues
+- **Issues**: https://github.com/NewsRx/opencode-gitbucket-superpowers/issues
 - **Release announcements**: [Sign up](https://primeradiant.com/superpowers/) to get notified about new versions

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -869,7 +869,7 @@ We now use Anthropic's first-party skills system!
 
 Superpowers v2.0 makes skills more accessible, maintainable, and community-driven through a major architectural shift.
 
-The headline change is **skills repository separation**: all skills, scripts, and documentation have moved from the plugin into a dedicated repository ([obra/superpowers-skills](https://github.com/obra/superpowers-skills)). This transforms superpowers from a monolithic plugin into a lightweight shim that manages a local clone of the skills repository. Skills auto-update on session start. Users fork and contribute improvements via standard git workflows. The skills library versions independently from the plugin.
+The headline change is **skills repository separation**: all skills, scripts, and documentation have moved from the plugin into a dedicated repository ([NewsRx/superpowers-skills](https://github.com/NewsRx/superpowers-skills)). This transforms superpowers from a monolithic plugin into a lightweight shim that manages a local clone of the skills repository. Skills auto-update on session start. Users fork and contribute improvements via standard git workflows. The skills library versions independently from the plugin.
 
 Beyond infrastructure, this release adds nine new skills focused on problem-solving, research, and architecture. We rewrote the core **using-skills** documentation with imperative tone and clearer structure, making it easier for Claude to understand when and how to use skills. **find-skills** now outputs paths you can paste directly into the Read tool, eliminating friction in the skills discovery workflow.
 
@@ -879,7 +879,7 @@ Users experience seamless operation: the plugin handles cloning, forking, and up
 
 ### Skills Repository Separation
 
-**The biggest change:** Skills no longer live in the plugin. They've been moved to a separate repository at [obra/superpowers-skills](https://github.com/obra/superpowers-skills).
+**The biggest change:** Skills no longer live in the plugin. They've been moved to a separate repository at [NewsRx/superpowers-skills](https://github.com/NewsRx/superpowers-skills).
 
 **What this means for you:**
 
@@ -894,7 +894,7 @@ Users experience seamless operation: the plugin handles cloning, forking, and up
 If you have an existing installation:
 1. Your old `~/.config/superpowers/.git` will be backed up to `~/.config/superpowers/.git.bak`
 2. Old skills will be backed up to `~/.config/superpowers/skills.bak`
-3. Fresh clone of obra/superpowers-skills will be created at `~/.config/superpowers/skills/`
+3. Fresh clone of NewsRx/superpowers-skills will be created at `~/.config/superpowers/skills/`
 
 ### Removed Features
 
@@ -1075,7 +1075,7 @@ The plugin handles everything automatically.
 
 ### For Contributors
 
-- Skills repository is now at https://github.com/obra/superpowers-skills
+- Skills repository is now at https://github.com/NewsRx/superpowers-skills
 - Fork → Branch → PR workflow
 - See skills/meta/writing-skills/SKILL.md for TDD approach to documentation
 
@@ -1091,6 +1091,6 @@ None at this time.
 
 ---
 
-**Full Changelog:** https://github.com/obra/superpowers/compare/dd013f6...main
-**Skills Repository:** https://github.com/obra/superpowers-skills
-**Issues:** https://github.com/obra/superpowers/issues
+**Full Changelog:** https://github.com/NewsRx/opencode-gitbucket-superpowers/compare/dd013f6...main
+**Skills Repository:** https://github.com/NewsRx/superpowers-skills
+**Issues:** https://github.com/NewsRx/opencode-gitbucket-superpowers/issues

--- a/docs/README.codex.md
+++ b/docs/README.codex.md
@@ -7,7 +7,7 @@ Guide for using Superpowers with OpenAI Codex via native skill discovery.
 Tell Codex:
 
 ```
-Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.codex/INSTALL.md
+Fetch and follow instructions from https://raw.githubusercontent.com/NewsRx/opencode-gitbucket-superpowers/refs/heads/main/.codex/INSTALL.md
 ```
 
 ## Manual Installation
@@ -21,7 +21,7 @@ Fetch and follow instructions from https://raw.githubusercontent.com/obra/superp
 
 1. Clone the repo:
    ```bash
-   git clone https://github.com/obra/superpowers.git ~/.codex/superpowers
+   git clone https://github.com/NewsRx/opencode-gitbucket-superpowers.git ~/.codex/superpowers
    ```
 
 2. Create the skills symlink:
@@ -122,5 +122,5 @@ Junctions normally work without special permissions. If creation fails, try runn
 
 ## Getting Help
 
-- Report issues: https://github.com/obra/superpowers/issues
-- Main documentation: https://github.com/obra/superpowers
+- Report issues: https://github.com/NewsRx/opencode-gitbucket-superpowers/issues
+- Main documentation: https://github.com/NewsRx/opencode-gitbucket-superpowers

--- a/docs/README.opencode.md
+++ b/docs/README.opencode.md
@@ -8,7 +8,7 @@ Add superpowers to the `plugin` array in your `opencode.json` (global or project
 
 ```json
 {
-  "plugin": ["superpowers@git+https://github.com/obra/superpowers.git"]
+  "plugin": ["superpowers@git+https://github.com/NewsRx/opencode-gitbucket-superpowers.git"]
 }
 ```
 
@@ -84,7 +84,7 @@ To pin a specific version, use a branch or tag:
 
 ```json
 {
-  "plugin": ["superpowers@git+https://github.com/obra/superpowers.git#v5.0.3"]
+  "plugin": ["superpowers@git+https://github.com/NewsRx/opencode-gitbucket-superpowers.git#v5.0.3"]
 }
 ```
 
@@ -125,6 +125,6 @@ Skills written for Claude Code are automatically adapted for OpenCode:
 
 ## Getting Help
 
-- Report issues: https://github.com/obra/superpowers/issues
-- Main documentation: https://github.com/obra/superpowers
+- Report issues: https://github.com/NewsRx/opencode-gitbucket-superpowers/issues
+- Main documentation: https://github.com/NewsRx/opencode-gitbucket-superpowers
 - OpenCode docs: https://opencode.ai/docs/

--- a/docs/plans/2025-11-22-opencode-support-implementation.md
+++ b/docs/plans/2025-11-22-opencode-support-implementation.md
@@ -780,7 +780,7 @@ git commit -m "feat: implement session.started hook for opencode"
 ```bash
 # Clone superpowers skills to OpenCode config directory
 mkdir -p ~/.config/opencode/superpowers
-git clone https://github.com/obra/superpowers.git ~/.config/opencode/superpowers
+git clone https://github.com/NewsRx/opencode-gitbucket-superpowers.git ~/.config/opencode/superpowers
 ```
 
 ### 2. Install the Plugin
@@ -878,8 +878,8 @@ When a skill references a Claude Code tool you don't have:
 
 ## Getting Help
 
-- Report issues: https://github.com/obra/superpowers/issues
-- Documentation: https://github.com/obra/superpowers
+- Report issues: https://github.com/NewsRx/opencode-gitbucket-superpowers/issues
+- Documentation: https://github.com/NewsRx/opencode-gitbucket-superpowers
 ```
 
 **Step 2: Verify file created**

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 # SessionStart hook for superpowers plugin
+#
+# This hook:
+# 1. Extracts git context via session_init.py (platform, owner, repo, credentials)
+# 2. Injects using-superpowers skill content
+# 3. Adds platform-specific tool guidance
 
 set -euo pipefail
 
@@ -14,8 +19,23 @@ if [ -d "$legacy_skills_dir" ]; then
     warning_message="\n\n<important-reminder>IN YOUR FIRST REPLY AFTER SEEING THIS MESSAGE YOU MUST TELL THE USER:⚠️ **WARNING:** Superpowers now uses Claude Code's skills system. Custom skills in ~/.config/superpowers/skills will not be read. Move custom skills to ~/.claude/skills instead. To make this message go away, remove ~/.config/superpowers/skills</important-reminder>"
 fi
 
+# Run session init script to extract git context
+# Output: DEV_NAME, DEV_EMAIL, GIT_OWNER, GIT_REPO, GIT_PLATFORM, etc.
+session_init_output=""
+if [ -x "${PLUGIN_ROOT}/scripts/session_init.py" ]; then
+    session_init_output=$("${PLUGIN_ROOT}/scripts/session_init.py" 2>/dev/null) || session_init_output=""
+elif command -v python3 >/dev/null 2>&1; then
+    session_init_output=$(python3 "${PLUGIN_ROOT}/scripts/session_init.py" 2>/dev/null) || session_init_output=""
+fi
+
 # Read using-superpowers content
 using_superpowers_content=$(cat "${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md" 2>&1 || echo "Error reading using-superpowers skill")
+
+# Read platform detection content (provides guidance on GitHub vs GitBucket)
+platform_detection_content=""
+if [ -f "${PLUGIN_ROOT}/skills/platform-detection.md" ]; then
+    platform_detection_content=$(cat "${PLUGIN_ROOT}/skills/platform-detection.md" 2>&1) || platform_detection_content=""
+fi
 
 # Escape string for JSON embedding using bash parameter substitution.
 # Each ${s//old/new} is a single C-level pass - orders of magnitude
@@ -32,7 +52,35 @@ escape_for_json() {
 
 using_superpowers_escaped=$(escape_for_json "$using_superpowers_content")
 warning_escaped=$(escape_for_json "$warning_message")
-session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
+session_init_escaped=$(escape_for_json "$session_init_output")
+platform_detection_escaped=$(escape_for_json "$platform_detection_content")
+
+# Build the context string
+# Format:
+#   1. Session init output (git context)
+#   2. using-superpowers skill
+#   3. platform-detection reference
+#   4. Warning about legacy skills
+session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n\n"
+
+# Add session init output if available
+if [ -n "$session_init_output" ]; then
+    session_context+="<GIT_CONTEXT>\n${session_init_escaped}\n</GIT_CONTEXT>\n\n"
+fi
+
+# Add platform detection reference if available
+if [ -n "$platform_detection_content" ]; then
+    session_context+="<PLATFORM_DETECTION>\n${platform_detection_escaped}\n</PLATFORM_DETECTION>\n\n"
+fi
+
+# Add skill invocation reminder based on platform detected
+if echo "$session_init_output" | grep -q "GIT_PLATFORM=github"; then
+    session_context+="<SKILL_REMINDER>\nPlatform: GitHub\n- Use GitHub tools (github_issue_write, github_create_issue, etc.) for issue tracking\n- Use GitHub tools (github_create_pull_request, github_merge_pull_request, etc.) for PRs\n- Skills that create issues will use GitHub MCP tools\n</SKILL_REMINDER>\n\n"
+elif echo "$session_init_output" | grep -q "GIT_PLATFORM=gitbucket"; then
+    session_context+="<SKILL_REMINDER>\nPlatform: GitBucket\n- Use GitBucket tools (gitbucket_create_issue, etc.) for issue tracking\n- Use GitBucket tools (gitbucket_create_pull_request, etc.) for PRs\n- Skills that create issues will use GitBucket API tools\n- Ensure GITBUCKET_URL and GITBUCKET_TOKEN are set in .env if using GitBucket API\n</SKILL_REMINDER>\n\n"
+fi
+
+session_context+="</EXTREMELY_IMPORTANT>"
 
 # Output context injection as JSON.
 # Cursor hooks expect additional_context (snake_case).
@@ -42,7 +90,7 @@ session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the 
 # deduplication, so we must emit only the field the current platform consumes.
 #
 # Uses printf instead of heredoc to work around bash 5.3+ heredoc hang.
-# See: https://github.com/obra/superpowers/issues/571
+# See: https://github.com/NewsRx/opencode-gitbucket-superpowers/issues/571
 if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
   # Cursor sets CURSOR_PLUGIN_ROOT (may also set CLAUDE_PLUGIN_ROOT)
   printf '{\n  "additional_context": "%s"\n}\n' "$session_context"

--- a/scripts/session_init.py
+++ b/scripts/session_init.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Session initialization script for AI agents.
+
+Extracts git context needed for agent startup:
+- DEV_NAME: Developer's git config name (for commit trailers)
+- DEV_EMAIL: Developer's git config email (for commit trailers)
+- GIT_OWNER: Repository owner (for GitHub/GitBucket API calls)
+- GIT_REPO: Repository name (for GitHub/GitBucket API calls)
+- GIT_HOOKS_PATH: Git hooks path (to verify hooks installed)
+- GIT_REMOTE_URL: Full remote URL (for reference)
+- GIT_PLATFORM: github, gitbucket, or unknown
+- GITBUCKET_URL: GitBucket base URL (if GitBucket detected)
+- GITBUCKET_HAS_CREDENTIALS: true/false (if credentials in .env)
+
+Usage:
+    uv run scripts/session_init.py
+
+Exit codes:
+    0: Success
+    1: No remote configured
+    2: Non-git remote detected
+
+Can also be run directly with Python 3.11+:
+    python scripts/session_init.py
+
+The script self-boots with no external dependencies.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+from urllib.parse import urlparse
+
+
+class GitContext(NamedTuple):
+    """Git context extracted from repository."""
+
+    dev_name: str
+    dev_email: str
+    hooks_path: str
+    remote_url: str
+    platform: str  # github, gitbucket, or unknown
+    owner: str | None
+    repo: str | None
+    gitbucket_url: str | None
+    gitbucket_has_credentials: bool
+
+
+def run_git_command(args: list[str]) -> str | None:
+    """Run a git command and return output, or None if failed."""
+    try:
+        result = subprocess.run(
+            ["git"] + args,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        pass
+    return None
+
+
+def get_user_name() -> str:
+    """Get git user name or fallback to $USER."""
+    name = run_git_command(["config", "user.name"])
+    if name:
+        return name
+    return os.environ.get("USER", "unknown")
+
+
+def get_user_email() -> str:
+    """Get git user email or fallback to $USER@$HOSTNAME."""
+    email = run_git_command(["config", "user.email"])
+    if email:
+        return email
+    user = os.environ.get("USER", "unknown")
+    hostname = os.environ.get("HOSTNAME", "localhost")
+    return f"{user}@{hostname}"
+
+
+def get_hooks_path() -> str:
+    """Get git hooks path or empty string if not configured."""
+    hooks = run_git_command(["config", "core.hooksPath"])
+    return hooks or ""
+
+
+def get_remote_url() -> str | None:
+    """Get origin remote URL or None if not configured."""
+    return run_git_command(["remote", "get-url", "origin"])
+
+
+def parse_github_url(url: str) -> tuple[str, str] | tuple[None, None]:
+    """Parse owner and repo from GitHub remote URL.
+
+    Supports:
+    - SSH: git@github.com:owner/repo.git
+    - HTTPS: https://github.com/owner/repo.git
+
+    Returns:
+        (owner, repo) on success, (None, None) on failure
+    """
+    # SSH format: git@github.com:owner/repo.git
+    ssh_pattern = r"^git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$"
+    match = re.match(ssh_pattern, url)
+    if match:
+        return match.group(1), match.group(2)
+
+    # HTTPS format: https://github.com/owner/repo.git
+    https_pattern = r"^https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$"
+    match = re.match(https_pattern, url)
+    if match:
+        return match.group(1), match.group(2)
+
+    return None, None
+
+
+def parse_gitbucket_url(url: str) -> tuple[str, str, str] | tuple[None, None, None]:
+    """Parse base URL, owner, and repo from GitBucket remote URL.
+
+    Supports:
+    - SSH: ssh://git@hostname:port/owner/repo.git
+    - SSH: git@hostname:owner/repo.git (no port)
+    - HTTPS: https://hostname/owner/repo.git
+
+    Returns:
+        (base_url, owner, repo) on success, (None, None, None) on failure
+    """
+    # SSH format: ssh://git@hostname:port/owner/repo.git
+    ssh_url_pattern = r"^ssh://git@([^:/]+):(\d+)/([^/]+)/([^/]+?)(?:\.git)?$"
+    match = re.match(ssh_url_pattern, url)
+    if match:
+        host = match.group(1)
+        owner = match.group(3)
+        repo = match.group(4)
+        base_url = f"https://{host}/gitbucket/"
+        return base_url, owner, repo
+
+    # SSH format: git@hostname:owner/repo.git (no port, colon separator)
+    ssh_short_pattern = r"^git@([^:]+):([^/]+)/([^/]+?)(?:\.git)?$"
+    match = re.match(ssh_short_pattern, url)
+    if match:
+        host = match.group(1)
+        # Skip if this is actually github.com
+        if host == "github.com":
+            return None, None, None
+        owner = match.group(2)
+        repo = match.group(3)
+        base_url = f"https://{host}/gitbucket/"
+        return base_url, owner, repo
+
+    # HTTPS format: https://hostname/owner/repo.git
+    https_pattern = r"^https://([^/]+)/([^/]+)/([^/]+?)(?:\.git)?$"
+    match = re.match(https_pattern, url)
+    if match:
+        host = match.group(1)
+        # Skip if this is actually github.com
+        if host == "github.com":
+            return None, None, None
+        owner = match.group(2)
+        repo = match.group(3)
+        base_url = f"https://{host}/gitbucket/"
+        return base_url, owner, repo
+
+    return None, None, None
+
+
+def check_gitbucket_credentials() -> bool:
+    """Check if GitBucket credentials exist in .env file.
+
+    Looks for .env in the repository root (relative to this script).
+
+    Returns:
+        True if both GITBUCKET_URL and GITBUCKET_TOKEN found, False otherwise
+    """
+    try:
+        # Get repo root relative to this script
+        script_path = Path(__file__).resolve()
+        env_path = script_path.parent.parent / ".env"
+
+        if env_path.exists():
+            content = env_path.read_text()
+            return "GITBUCKET_TOKEN=" in content and "GITBUCKET_URL=" in content
+    except (IOError, OSError):
+        pass
+
+    return False
+
+
+def is_github_remote(url: str) -> bool:
+    """Check if remote URL is a GitHub remote by extracting hostname.
+
+    Properly parses URL to check hostname, avoiding substring matching issues.
+    """
+    # Handle SSH format: git@github.com:owner/repo.git
+    if url.startswith("git@"):
+        match = re.match(r"^git@([^:]+):", url)
+        if match:
+            hostname = match.group(1)
+            return hostname == "github.com"
+
+    # Handle HTTPS format: https://github.com/owner/repo.git
+    try:
+        parsed = urlparse(url)
+        if parsed.hostname:
+            return parsed.hostname == "github.com"
+    except Exception:
+        pass
+
+    return False
+
+
+def extract_git_context() -> GitContext | None:
+    """Extract git context from repository.
+
+    Returns:
+        GitContext on success, None if no remote configured
+    """
+    remote_url = get_remote_url()
+    if not remote_url:
+        return None
+
+    user_name = get_user_name()
+    user_email = get_user_email()
+    hooks_path = get_hooks_path()
+
+    # Check if GitHub remote (properly validated)
+    if is_github_remote(remote_url):
+        owner, repo = parse_github_url(remote_url)
+        if owner and repo:
+            return GitContext(
+                dev_name=user_name,
+                dev_email=user_email,
+                hooks_path=hooks_path,
+                remote_url=remote_url,
+                platform="github",
+                owner=owner,
+                repo=repo,
+                gitbucket_url=None,
+                gitbucket_has_credentials=False,
+            )
+
+    # GitBucket remote (non-GitHub git remote)
+    base_url, owner, repo = parse_gitbucket_url(remote_url)
+    if base_url and owner and repo:
+        has_creds = check_gitbucket_credentials()
+        return GitContext(
+            dev_name=user_name,
+            dev_email=user_email,
+            hooks_path=hooks_path,
+            remote_url=remote_url,
+            platform="gitbucket",
+            owner=owner,
+            repo=repo,
+            gitbucket_url=base_url,
+            gitbucket_has_credentials=has_creds,
+        )
+
+    # Unknown remote type
+    return GitContext(
+        dev_name=user_name,
+        dev_email=user_email,
+        hooks_path=hooks_path,
+        remote_url=remote_url,
+        platform="unknown",
+        owner=None,
+        repo=None,
+        gitbucket_url=None,
+        gitbucket_has_credentials=False,
+    )
+
+
+def format_output(ctx: GitContext) -> str:
+    """Format git context for output."""
+    lines = [
+        "# Session Init - Git Context",
+        f"DEV_NAME={ctx.dev_name}",
+        f"DEV_EMAIL={ctx.dev_email}",
+        f"GIT_HOOKS_PATH={ctx.hooks_path}",
+        f"GIT_REMOTE_URL={ctx.remote_url}",
+    ]
+
+    if ctx.platform == "github":
+        lines.extend(
+            [
+                f"GIT_OWNER={ctx.owner}",
+                f"GIT_REPO={ctx.repo}",
+                "GIT_PLATFORM=github",
+                "",
+                "# GitHub Repository Detected",
+                "# Use GitHub tools (github_create_issue, github_issue_write, etc.) for issue tracking",
+            ]
+        )
+
+    elif ctx.platform == "gitbucket":
+        lines.extend(
+            [
+                f"GIT_OWNER={ctx.owner}",
+                f"GIT_REPO={ctx.repo}",
+                "GIT_PLATFORM=gitbucket",
+                f"GITBUCKET_URL={ctx.gitbucket_url}",
+                f"GITBUCKET_HAS_CREDENTIALS={'true' if ctx.gitbucket_has_credentials else 'false'}",
+                "",
+                "# GitBucket Repository Detected",
+                "# Use GitBucket tools (gitbucket_create_issue, etc.) for issue tracking",
+            ]
+        )
+
+        if not ctx.gitbucket_has_credentials:
+            lines.extend(
+                [
+                    "# WARNING: GITBUCKET_URL and/or GITBUCKET_TOKEN not found in .env",
+                    "# Set these credentials for GitBucket API access",
+                ]
+            )
+
+    else:  # unknown
+        lines.append("GIT_PLATFORM=unknown")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    """Extract and output git context."""
+    ctx = extract_git_context()
+
+    if ctx is None:
+        print("ERROR: No git remote configured", file=sys.stderr)
+        print("Run: git remote add origin <url>", file=sys.stderr)
+        return 1
+
+    if ctx.platform == "unknown":
+        print("WARNING: Unknown remote type", file=sys.stderr)
+        print(f"Remote URL: {ctx.remote_url}", file=sys.stderr)
+
+    print(format_output(ctx))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -106,29 +106,57 @@ digraph brainstorming {
 
 ## After the Design
 
-**Documentation:**
+**Create Spec Issue (REQUIRED):**
 
-- Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
-  - (User preferences for spec location override this default)
-- Use elements-of-style:writing-clearly-and-concisely skill if available
-- Commit the design document to git
+Specs are stored as GitHub/GitBucket issues. No local file storage.
+
+Check `GIT_PLATFORM` in your session context (`<GIT_CONTEXT>` block):
+
+- If `GIT_PLATFORM=github`:
+  ```markdown
+  Use github_issue_write with:
+  - method: "create"
+  - title: [Spec] <topic>
+  - body: Full design specification (all sections, complete content)
+  - labels: spec, plus relevant feature labels
+  ```
+
+- Else if `GIT_PLATFORM=gitbucket`:
+  ```markdown
+  First, check GITBUCKET_HAS_CREDENTIALS:
+  - If false: STOP. Tell user "GitBucket credentials required. Set GITBUCKET_URL and GITBUCKET_TOKEN in .env, then restart session."
+  - If true: Proceed with gitbucket_create_issue
+  
+  Use gitbucket_create_issue with:
+  - title: [Spec] <topic>
+  - body: Full design specification (all sections, complete content)
+  - labels: spec, plus relevant feature labels
+  ```
+
+- Else (unknown):
+  ```markdown
+  STOP. Tell user "No GitHub/GitBucket remote detected. Configure git remote to enable spec tracking."
+  Do not proceed until platform is configured.
+  ```
+
+The issue body should contain the complete spec. Do not link to a file - put all design content in the issue.
 
 **Spec Self-Review:**
-After writing the spec document, look at it with fresh eyes:
+After creating the issue, review the spec content with fresh eyes:
 
-1. **Placeholder scan:** Any "TBD", "TODO", incomplete sections, or vague requirements? Fix them.
-2. **Internal consistency:** Do any sections contradict each other? Does the architecture match the feature descriptions?
+1. **Placeholder scan:** Any "TBD", "TODO", incomplete sections, or vague requirements? Edit the issue to fix them.
+2. **Internal consistency:** Do any sections contradict each other? Does the architecture match the feature descriptions? Edit to fix.
 3. **Scope check:** Is this focused enough for a single implementation plan, or does it need decomposition?
-4. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, pick one and make it explicit.
+4. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, edit to make it explicit.
 
-Fix any issues inline. No need to re-review — just fix and move on.
+Edit the issue inline to fix any problems. No need to re-review — just fix and move on.
 
 **User Review Gate:**
-After the spec review loop passes, ask the user to review the written spec before proceeding:
+After the spec review loop passes, ask the user to review the spec issue:
 
-> "Spec written and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
+> "Spec created as issue #<number>. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
 
-Wait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves.
+Share the issue URL so the user can review directly. If they request changes, edit the issue and re-run the spec review loop. Only proceed once the user approves.
 
 **Implementation:**
 

--- a/skills/brainstorming/scripts/frame-template.html
+++ b/skills/brainstorming/scripts/frame-template.html
@@ -196,7 +196,7 @@
 </head>
 <body>
   <div class="header">
-    <h1><a href="https://github.com/obra/superpowers" style="color: inherit; text-decoration: none;">Superpowers Brainstorming</a></h1>
+    <h1><a href="https://github.com/NewsRx/opencode-gitbucket-superpowers" style="color: inherit; text-decoration: none;">Superpowers Brainstorming</a></h1>
     <div class="status">Connected</div>
   </div>
 

--- a/skills/platform-detection.md
+++ b/skills/platform-detection.md
@@ -1,0 +1,74 @@
+# Platform Detection (GitBucket vs GitHub)
+
+Skills that interact with issue tracking, specs, and plans must detect which platform is available and adapt accordingly.
+
+## Automatic Detection at Session Start
+
+When an agent session starts, the plugin automatically runs `scripts/session_init.py` which:
+
+1. **Extracts git remote URL** from `git remote get-url origin`
+2. **Detects platform** from URL pattern:
+   - URLs containing `github.com` → `GIT_PLATFORM=github`
+   - All other git URLs → `GIT_PLATFORM=gitbucket`
+3. **Parses owner/repo** for API calls
+4. **Checks credentials** for GitBucket (`.env` file for `GITBUCKET_URL` and `GITBUCKET_TOKEN`)
+5. **Injects context** into agent session:
+   ```
+   <GIT_CONTEXT>
+   DEV_NAME=...
+   DEV_EMAIL=...
+   GIT_OWNER=...
+   GIT_REPO=...
+   GIT_PLATFORM=github|gitbucket|unknown
+   GITBUCKET_URL=... (if GitBucket)
+   GITBUCKET_HAS_CREDENTIALS=true|false (if GitBucket)
+   </GIT_CONTEXT>
+   ```
+
+## Skill Integration Pattern
+
+Skills MUST use the detected platform to create issues:
+
+```markdown
+### In the agent context:
+
+Check <GIT_CONTEXT> for GIT_PLATFORM:
+- github → Use GitHub tools (github_issue_write, github_create_pull_request, etc.)
+- gitbucket → Use GitBucket tools (gitbucket_create_issue, gitbucket_create_pull_request, etc.)
+
+For GitBucket:
+- Check GITBUCKET_HAS_CREDENTIALS
+- If false, STOP and warn user to set GITBUCKET_URL and GITBUCKET_TOKEN in .env
+- Do not proceed until credentials are configured
+
+All specs, plans, and bug reports are stored as issues. No local file fallback.
+```
+
+## Example: Creating a Spec Issue
+
+```markdown
+After brainstorming, create a spec issue:
+
+Check GIT_PLATFORM from session context:
+
+If GIT_PLATFORM=github:
+  Use github_issue_write with:
+  - title: [Spec] <topic>
+  - body: Full design specification (all sections, complete content)
+  - labels: spec, plus relevant feature labels
+
+If GIT_PLATFORM=gitbucket:
+  Check GITBUCKET_HAS_CREDENTIALS:
+  - If false: STOP. Tell user "GitBucket credentials required. Set GITBUCKET_URL and GITBUCKET_TOKEN in .env"
+  - If true: Proceed with gitbucket_create_issue
+
+  Use gitbucket_create_issue with:
+  - title: [Spec] <topic>
+  - body: Full design specification (all sections, complete content)
+  - labels: spec, plus relevant feature labels
+
+If GIT_PLATFORM=unknown:
+  STOP. Tell user "No GitHub/GitBucket remote detected. Configure git remote to enable spec tracking."
+
+Never write specs to local files. Only issues.
+```

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -178,25 +178,73 @@ You MUST complete each phase before proceeding to the next.
    - MUST have before fixing
    - Use the `superpowers:test-driven-development` skill for writing proper failing tests
 
-2. **Implement Single Fix**
+2. **Create Bug Issue (REQUIRED)**
+
+   Bugs are tracked as GitHub/GitBucket issues. No local file storage.
+   
+   Check `GIT_PLATFORM` in your session context (`<GIT_CONTEXT>` block):
+   
+   - If `GIT_PLATFORM=github`:
+     ```markdown
+     Use github_issue_write with:
+     - method: "create"
+     - title: [Bug] <brief description>
+     - body:
+       ## Summary
+       <one sentence description>
+       
+       ## Root Cause
+       <what you found in investigation>
+       
+       ## Reproduction
+       <steps to trigger>
+       
+       ## Evidence
+       <relevant logs, stack traces, data>
+       
+       ## Proposed Fix
+       <what you're about to implement>
+     - labels: bug
+     ```
+   
+   - Else if `GIT_PLATFORM=gitbucket`:
+     ```markdown
+     First, check GITBUCKET_HAS_CREDENTIALS:
+     - If false: STOP. Tell user "GitBucket credentials required."
+     - If true: Proceed with gitbucket_create_issue
+     
+     Use gitbucket_create_issue with:
+     - title: [Bug] <brief description>
+     - body: (same structure as above)
+     - labels: bug
+     ```
+   
+   - Else (unknown):
+     ```markdown
+     STOP. Tell user "No GitHub/GitBucket remote detected."
+     ```
+   
+   See `../platform-detection.md` for details.
+
+3. **Implement Single Fix**
    - Address the root cause identified
    - ONE change at a time
    - No "while I'm here" improvements
    - No bundled refactoring
 
-3. **Verify Fix**
+4. **Verify Fix**
    - Test passes now?
    - No other tests broken?
    - Issue actually resolved?
 
-4. **If Fix Doesn't Work**
+5. **If Fix Doesn't Work**
    - STOP
    - Count: How many fixes have you tried?
    - If < 3: Return to Phase 1, re-analyze with new information
-   - **If ≥ 3: STOP and question the architecture (step 5 below)**
+   - **If ≥ 3: STOP and question the architecture (step 6 below)**
    - DON'T attempt Fix #4 without architectural discussion
 
-5. **If 3+ Fixes Failed: Question Architecture**
+6. **If 3+ Fixes Failed: Question Architecture**
 
    **Pattern indicating architectural problem:**
    - Each fix reveals new shared state/coupling/problem in different place

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -15,8 +15,7 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Context:** This should be run in a dedicated worktree (created by brainstorming skill).
 
-**Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
-- (User preferences for plan location override this default)
+**Store plans as issues:** Plans are stored in GitHub/GitBucket issues (not local files). Check `GIT_PLATFORM` from session context and use appropriate issue creation tool.
 
 ## Scope Check
 
@@ -119,23 +118,66 @@ Every step must contain the actual content an engineer needs. These are **plan f
 - Exact commands with expected output
 - DRY, YAGNI, TDD, frequent commits
 
+## After the Plan
+
+**Create Plan Issue (REQUIRED):**
+
+Plans are stored as GitHub/GitBucket issues. No local file storage.
+
+Check `GIT_PLATFORM` in your session context (`<GIT_CONTEXT>` block):
+
+- If `GIT_PLATFORM=github`:
+  ```markdown
+  Use github_issue_write with:
+  - method: "create"
+  - title: [Plan] <feature-name> Implementation
+  - body: Full implementation plan (all tasks, all steps, complete code)
+  - labels: plan
+  ```
+
+- Else if `GIT_PLATFORM=gitbucket`:
+  ```markdown
+  First, check GITBUCKET_HAS_CREDENTIALS:
+  - If false: STOP. Tell user "GitBucket credentials required."
+  - If true: Proceed with gitbucket_create_issue
+  
+  Use gitbucket_create_issue with:
+  - title: [Plan] <feature-name> Implementation
+  - body: Full implementation plan (all tasks, all steps, complete code)
+  - labels: plan
+  ```
+
+- Else (unknown):
+  ```markdown
+  STOP. Tell user "No GitHub/GitBucket remote detected."
+  ```
+
+The issue body should contain the complete plan. Do not link to a file - put all implementation content in the issue.
+
+**Link to Spec Issue:**
+
+Comment on the spec issue to link this plan:
+
+- If GitHub: `github_add_issue_comment(spec_issue_number, "Implementation plan: #<plan_issue_number>")`
+- If GitBucket: `gitbucket_add_issue_comment(spec_issue_number, "Implementation plan: #<plan_issue_number>")`
+
 ## Self-Review
 
-After writing the complete plan, look at the spec with fresh eyes and check the plan against it. This is a checklist you run yourself — not a subagent dispatch.
+After writing the complete plan, review with fresh eyes:
 
-**1. Spec coverage:** Skim each section/requirement in the spec. Can you point to a task that implements it? List any gaps.
+**1. Spec coverage:** Skim each section/requirement in the spec issue. Can you point to a task that implements it? Edit the plan issue to add missing tasks.
 
-**2. Placeholder scan:** Search your plan for red flags — any of the patterns from the "No Placeholders" section above. Fix them.
+**2. Placeholder scan:** Search your plan for red flags — any of the patterns from the "No Placeholders" section above. Edit the issue to fix them.
 
-**3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
+**3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug. Edit to fix.
 
-If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
+Fix issues by editing the plan issue. No need to re-review — just fix and move on.
 
 ## Execution Handoff
 
-After saving the plan, offer execution choice:
+After creating the plan issue, offer execution choice:
 
-**"Plan complete and saved to `docs/superpowers/plans/<filename>.md`. Two execution options:**
+**"Plan created as issue #<number>. Two execution options:**
 
 **1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
 


### PR DESCRIPTION
## Summary

- Changed all repository references from `obra/superpowers` to `NewsRx/opencode-gitbucket-superpowers`
- Added automatic platform detection (GitHub vs GitBucket) at session start
- Enforced 100% issue-based storage for specs, plans, and bugs

## Changes

### Repository URL Updates
- Updated plugin configs (`.opencode/`, `.codex/`, `.claude-plugin/`, `.cursor-plugin/`)
- Updated INSTALL files for all platforms
- Updated READMEs and documentation
- Updated CHANGELOG and RELEASE-NOTES references

### Platform Detection System
- Created `scripts/session_init.py` - Python script that:
  - Detects `GIT_PLATFORM` from git remote URL (github/gitbucket/unknown)
  - Extracts owner/repo for API calls
  - Checks GitBucket credentials in `.env`
- Modified `hooks/session-start` to inject platform context into agent session

### 100% Issue-Based Workflow
- Skills now **STOP** if platform not configured
- No local file fallbacks - forces issue tracking
- Updated skills to use `GIT_PLATFORM` from session context:
  - `brainstorming`: Creates spec issues
  - `writing-plans`: Creates plan issues, links to spec
  - `systematic-debugging`: Creates bug issues

## Session Context Injection

```
<GIT_CONTEXT>
DEV_NAME=...
DEV_EMAIL=...
GIT_OWNER=...
GIT_REPO=...
GIT_PLATFORM=github|gitbucket|unknown
GITBUCKET_URL=... (if GitBucket)
GITBUCKET_HAS_CREDENTIALS=true|false
</GIT_CONTEXT>
```

## Testing

Tested locally:
- Platform detection correctly identifies GitHub vs GitBucket remotes
- Session init runs on startup
- Skills reference `GIT_PLATFORM` from injected context