### PR TITLE
Add opencode.jsonc project config

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["superpowers@git+https://github.com/NewsRx/opencode-gitbucket-superpowers.git"]
+}


### PR DESCRIPTION
## What problem are you solving?

Project lacks an `opencode.jsonc` config file. OpenCode users cloning this repo need to manually configure the plugin. Adding a project-level config makes the plugin auto-load.

## What does this PR change?

Adds `opencode.jsonc` in project root with:
- `$schema` reference for IDE support
- `plugin` field loading superpowers from git repo

## Is this change appropriate for the core library?

Yes. This is core infrastructure - the config file needed for the plugin to work when cloned.

## What alternatives did you consider?

None. This is the standard OpenCode configuration approach.

## Does this PR contain multiple unrelated changes?

No, single file addition.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| OpenCode CLI | latest | GLM-5 | ollama-cloud/glm-5 |

## Evaluation

- Initial prompt: "create a project-specific opencode.json file"
- 1 eval session
- JSONC format allows comments, JSON schema enables IDE validation

## Rigor

- [x] If this is a skills change: N/A (config file, not skill)
- [x] Tested adversarially: N/A (single config file)
- [x] Did not modify behavior-shaping content

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission